### PR TITLE
(#32) keep a stat of succesfully provisioned nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ The daemon keeps a number of Prometheus format stats and will expose it in `/met
 |choria_provisioner_provision_errors|How many times provisioning failed|
 |choria_provisioner_paused|1 when the backplane paused operations, 0 otherwise|
 |choria_provisioner_busy_workers|How many workers are busy processing servers|
+|choria_provisioner_provisioned|Host many nodes were successfully provisioned|
 
 #### Packages
 

--- a/agent/ddl.go
+++ b/agent/ddl.go
@@ -1,6 +1,6 @@
 package provision
 
-// auto generated 2018-08-09 08:11:51.530618177 +0200 CEST m=+0.000797138
+// auto generated 2018-08-09 06:53:43.722376532 +0000 UTC m=+0.003910814
 
 import (
 	"encoding/base64"

--- a/host/host.go
+++ b/host/host.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/choria-io/go-choria/choria"
 	provision "github.com/choria-io/provisioning-agent/agent"
@@ -13,14 +12,13 @@ import (
 )
 
 type Host struct {
-	Identity        string              `json:"identity"`
-	CSR             *provision.CSRReply `json:"csr"`
-	Metadata        string              `json:"inventory"`
-	config          map[string]string
-	provisionExpire time.Time
-	provisioned     bool
-	ca              string
-	cert            string
+	Identity    string              `json:"identity"`
+	CSR         *provision.CSRReply `json:"csr"`
+	Metadata    string              `json:"inventory"`
+	config      map[string]string
+	provisioned bool
+	ca          string
+	cert        string
 
 	cfg       *config.Config
 	token     string
@@ -32,13 +30,12 @@ type Host struct {
 
 func NewHost(identity string, conf *config.Config) *Host {
 	return &Host{
-		Identity:        identity,
-		provisionExpire: time.Now().Add(time.Minute),
-		provisioned:     false,
-		mu:              &sync.Mutex{},
-		replylock:       &sync.Mutex{},
-		token:           conf.Token,
-		cfg:             conf,
+		Identity:    identity,
+		provisioned: false,
+		mu:          &sync.Mutex{},
+		replylock:   &sync.Mutex{},
+		token:       conf.Token,
+		cfg:         conf,
 	}
 }
 
@@ -53,9 +50,7 @@ func (h *Host) Provision(ctx context.Context, fw *choria.Framework) error {
 	h.fw = fw
 	h.log = fw.Logger(h.Identity)
 
-	var err error
-
-	err = h.fetchInventory(ctx)
+	err := h.fetchInventory(ctx)
 	if err != nil {
 		return fmt.Errorf("could not provision %s: %s", h.Identity, err)
 	}

--- a/hosts/hosts.go
+++ b/hosts/hosts.go
@@ -68,6 +68,7 @@ func Process(ctx context.Context, cfg *config.Config, cfw *choria.Framework) err
 	timer := time.NewTicker(cfg.IntervalDuration)
 
 	discoveredCtr.WithLabelValues(conf.Site).Add(0.0)
+	provisionedCtr.WithLabelValues(conf.Site).Add(0.0)
 
 	discover(ctx, agent)
 

--- a/hosts/stats.go
+++ b/hosts/stats.go
@@ -32,6 +32,11 @@ var (
 		Name: "choria_provisioner_busy_workers",
 		Help: "How many workers are busy provisioning nodes",
 	}, []string{"site"})
+
+	provisionedCtr = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "choria_provisioner_provisioned",
+		Help: "How many nodes were succesfully provisioned",
+	}, []string{"site"})
 )
 
 func init() {
@@ -41,4 +46,5 @@ func init() {
 	prometheus.MustRegister(errCtr)
 	prometheus.MustRegister(provErrCtr)
 	prometheus.MustRegister(busyWorkerGauge)
+	prometheus.MustRegister(provisionedCtr)
 }


### PR DESCRIPTION
Also fixes a small race where provisioned node is in its reboot splay
when a discovery run which means it will be discovered while already
being provisioned