### PR TITLE
(#72) reject cert requests matching choria client trusted names

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,15 @@ choria_insecure: true
 # a site name exposed to the backplane to assist with discovery, also used in stats
 site: testing
 
+# Certificate patterns that should never be signed from CSRs, these are ones choria
+# set aside as client only certificates and someone might configure a node to obtain
+# a signed cert otherwise.  When not set below is the default value
+cert_deny_list:
+  - "\.choria$"
+  - "\.mcollective$"
+  - "\.privileged.choria$"
+  - "\.privileged.mcollective$"
+
 # if not 0 then /metrics will be prometheus metrics
 monitor_port: 9999
 

--- a/config/config.go
+++ b/config/config.go
@@ -18,16 +18,17 @@ var Version = "0.0.0"
 
 // Config is the configuration structure
 type Config struct {
-	Workers     int                              `json:"workers"`
-	Interval    string                           `json:"interval"`
-	Logfile     string                           `json:"logfile"`
-	Loglevel    string                           `json:"loglevel"`
-	Helper      string                           `json:"helper"`
-	Token       string                           `json:"token"`
-	Insecure    bool                             `json:"choria_insecure"`
-	Site        string                           `json:"site"`
-	MonitorPort int                              `json:"monitor_port"`
-	Management  *backplane.StandardConfiguration `yaml:"management"`
+	Workers      int                              `json:"workers"`
+	Interval     string                           `json:"interval"`
+	Logfile      string                           `json:"logfile"`
+	Loglevel     string                           `json:"loglevel"`
+	Helper       string                           `json:"helper"`
+	Token        string                           `json:"token"`
+	Insecure     bool                             `json:"choria_insecure"`
+	Site         string                           `json:"site"`
+	MonitorPort  int                              `json:"monitor_port"`
+	Management   *backplane.StandardConfiguration `json:"management" yaml:"management"`
+	CertDenyList []string                         `json:"cert_deny_list"`
 
 	Features struct {
 		PKI bool `json:"pki"`
@@ -63,6 +64,15 @@ func Load(file string) (*Config, error) {
 	err = json.Unmarshal(j, &config)
 	if err != nil {
 		return nil, fmt.Errorf("could not parse config file %s as YAML: %s", file, err)
+	}
+
+	if len(config.CertDenyList) == 0 {
+		config.CertDenyList = []string{
+			"\\.privileged.mcollective$",
+			"\\.privileged.choria$",
+			"\\.mcollective$",
+			"\\.choria$",
+		}
 	}
 
 	config.IntervalDuration, err = time.ParseDuration(config.Interval)

--- a/host/host.go
+++ b/host/host.go
@@ -2,7 +2,11 @@ package host
 
 import (
 	"context"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
+	"regexp"
+	"strings"
 	"sync"
 
 	"github.com/choria-io/go-choria/choria"
@@ -60,6 +64,11 @@ func (h *Host) Provision(ctx context.Context, fw *choria.Framework) error {
 		if err != nil {
 			return fmt.Errorf("could not provision %s: %s", h.Identity, err)
 		}
+
+		err = h.validateCSR()
+		if err != nil {
+			return fmt.Errorf("could not provision %s: %s", h.Identity, err)
+		}
 	}
 
 	config, err := h.getConfig(ctx)
@@ -93,4 +102,50 @@ func (h *Host) Provision(ctx context.Context, fw *choria.Framework) error {
 
 func (h *Host) String() string {
 	return h.Identity
+}
+
+func (h *Host) validateCSR() error {
+	if h.CSR.CSR == "" {
+		return fmt.Errorf("no CSR received")
+	}
+
+	block, _ := pem.Decode([]byte(h.CSR.CSR))
+	csr, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		return fmt.Errorf("could not parse CSR: %s", err)
+	}
+
+	names := []string{csr.Subject.CommonName}
+	for _, name := range csr.DNSNames {
+		names = append(names, name)
+	}
+
+	if csr.Subject.CommonName != h.Identity {
+		return fmt.Errorf("common name %s does not match identity %s", csr.Subject.CommonName, h.Identity)
+	}
+
+	for _, name := range names {
+		if matchAnyRegex(name, h.cfg.CertDenyList) {
+			h.log.Errorf("Denying CSR with name %s due to pattern %s", name, strings.Join(h.cfg.CertDenyList, ", "))
+
+			return fmt.Errorf("%s matches denied certificate pattern", name)
+		}
+	}
+
+	return nil
+}
+
+func matchAnyRegex(str string, regex []string) bool {
+	for _, reg := range regex {
+		if matched, _ := regexp.MatchString("^/.+/$", reg); matched {
+			reg = strings.TrimLeft(reg, "/")
+			reg = strings.TrimRight(reg, "/")
+		}
+
+		if matched, _ := regexp.MatchString(reg, str); matched {
+			return true
+		}
+	}
+
+	return false
 }

--- a/host/host_test.go
+++ b/host/host_test.go
@@ -1,0 +1,134 @@
+package host
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/choria-io/provisioning-agent/agent"
+	"github.com/choria-io/provisioning-agent/config"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestChoria(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Host")
+}
+
+var _ = Describe("Host", func() {
+	var h *Host
+
+	BeforeEach(func() {
+		log := logrus.NewEntry(logrus.New())
+		log.Logger.Out = ioutil.Discard
+
+		h = &Host{
+			Identity: "ginkgo.example.net",
+			CSR:      &provision.CSRReply{},
+			log:      log,
+			cfg: &config.Config{
+				CertDenyList: []string{
+					"\\.privileged.mcollective$",
+					"\\.privileged.choria$",
+					"\\.mcollective$",
+					"\\.choria$",
+				},
+			},
+		}
+	})
+
+	Describe("validateCSR", func() {
+		It("Should handle no CSR", func() {
+			Expect(h.validateCSR()).To(MatchError("no CSR received"))
+		})
+
+		It("Should ensure the names match identity", func() {
+			csr, _, err := gencsr("notme.example.net", []string{})
+			Expect(err).ToNot(HaveOccurred())
+			h.CSR.CSR = string(csr)
+			Expect(h.validateCSR()).To(MatchError("common name notme.example.net does not match identity ginkgo.example.net"))
+		})
+
+		It("Should catch bad common names", func() {
+			for _, name := range strings.Fields("bob.choria bob.mcollective bob.privileged.choria bob.privileged.mcollective") {
+				h.Identity = name
+				csr, _, err := gencsr(name, []string{})
+				Expect(err).ToNot(HaveOccurred())
+				h.CSR.CSR = string(csr)
+				Expect(h.validateCSR()).To(MatchError(fmt.Sprintf("%s matches denied certificate pattern", name)))
+			}
+		})
+
+		It("Should catch bad DNS names", func() {
+			for _, name := range strings.Fields("bob.choria bob.mcollective bob.privileged.choria bob.privileged.mcollective") {
+				csr, _, err := gencsr("ginkgo.example.net", []string{"something.something", name, "something.else"})
+				Expect(err).ToNot(HaveOccurred())
+				h.CSR.CSR = string(csr)
+				Expect(h.validateCSR()).To(MatchError(fmt.Sprintf("%s matches denied certificate pattern", name)))
+			}
+		})
+
+		It("Should handle valid names", func() {
+			csr, _, err := gencsr("ginkgo.example.net", []string{"something.something", "something.else"})
+			Expect(err).ToNot(HaveOccurred())
+			h.CSR.CSR = string(csr)
+			Expect(h.validateCSR()).To(BeNil())
+		})
+	})
+})
+
+func gencsr(cn string, altnames []string) (csr []byte, key []byte, err error) {
+	if cn == "" {
+		return csr, key, fmt.Errorf("common name is required")
+	}
+
+	subj := pkix.Name{
+		CommonName: cn,
+	}.ToRDNSequence()
+
+	asn1Subj, err := asn1.Marshal(subj)
+	if err != nil {
+		return csr, key, err
+	}
+
+	template := x509.CertificateRequest{
+		RawSubject:         asn1Subj,
+		SignatureAlgorithm: x509.SHA256WithRSA,
+	}
+
+	if len(altnames) > 0 {
+		template.DNSNames = altnames
+	}
+
+	keyBytes, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return csr, key, err
+	}
+
+	key = pem.EncodeToMemory(
+		&pem.Block{
+			Type:  "RSA PRIVATE KEY",
+			Bytes: x509.MarshalPKCS1PrivateKey(keyBytes),
+		},
+	)
+
+	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, &template, keyBytes)
+	if err != nil {
+		return csr, key, err
+	}
+
+	csr = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrBytes})
+
+	return csr, key, nil
+}


### PR DESCRIPTION
Choria has a list of certificates it allows for clients - *.choria,
*.mcollective, *.privileged.choria etc - we should never sign certs
for these since someone might set a node FQDN / Identity to one of
these and take it through provisioning flow in order to get certs

This now rejects the default list and allows it to be configured